### PR TITLE
change state=running to restarted

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,6 @@
 - include: config.yml
 
 - name: Be sure sphinxsearch is running and enabled
-  service: name=sphinxsearch state=running enabled=yes
+  service: name=sphinxsearch state=restarted enabled=yes
   tags:
     - test

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -5,6 +5,5 @@
   when: ansible_os_family == "Debian" and ansible_distribution_release == "jessie"
 
 - name: Install the sphinx package
-  apt: name={{ item }} state=present update_cache=yes
-  with_items: "{{ ubuntu_pkg }}"
+  apt: name={{ ubuntu_pkg }} state=present update_cache=yes
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
Ansible fails with:
> value of state must be one of:
> reloaded, restarted, started, stopped, got: running

Change running to restarted.

Also fix apt loop deprecation.