### PR TITLE
Remove max_matches from configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ sphinx_searchd:
   read_timeout: 5
   max_children: 30
   pid_file: "/var/run/sphinxsearch/searchd.pid"
-  max_matches: 1000
   seamless_rotate: 1
   preopen_indexes: 1
   unlink_old: 1

--- a/templates/mail/sphinx_conf.j2
+++ b/templates/mail/sphinx_conf.j2
@@ -864,11 +864,6 @@ searchd
 	# mandatory
 	pid_file		= /var/run/sphinxsearch/searchd.pid
 
-	# max amount of matches the daemon ever keeps in RAM, per-index
-	# WARNING, THERE'S ALSO PER-QUERY LIMIT, SEE SetLimits() API CALL
-	# default is 1000 (just like Google)
-	max_matches		= 1000
-
 	# seamless rotate, prevents rotate stalls if precaching huge datasets
 	# optional, default is 1
 	seamless_rotate		= 1


### PR DESCRIPTION
The 'max_matches' setting was permanently removed from the configuration
file in Sphinx 2.2.3-beta. An option with the same name is still
available per-query and it is 1000 by default just like it was in the
default config as well. Thus, it is sufficient to remove the setting
from the configurations in this role.

More information:
https://sphinxsearch.com/docs/manual-2.3.2.html#sphinx-deprecations-defaults
https://sphinxsearch.com/docs/manual-2.3.2.html#sphinxql-select

This patch removes the following reoccurring warning in the logs:

    WARNING: key 'max_matches' was permanently removed from Sphinx
    configuration. Refer to documentation for details.

Note: The upstream has been updated but this change concerns a
part that does not exist there. The master branch does not
merge cleanly either.