### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -18,5 +18,5 @@
     - rotate all indexes
     - restart sphinx
 
-- include: ext_config.yml
+- include_tasks: ext_config.yml
   when: sphinx_use_ext_config == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 
-- include: package.yml
+- include_tasks: package.yml
   when: sphinx_conf_only is not defined
 
-- include: test.yml
+- include_tasks: test.yml
   when: sphinx_test
 
-- include: mail.yml
+- include_tasks: mail.yml
   when: ansible_hostname == "mail2"
 
-- include: config.yml
+- include_tasks: config.yml
 
 - name: Be sure sphinxsearch is running and enabled
   service: name=sphinxsearch state=started enabled=yes


### PR DESCRIPTION
Change deprecated include to include_tasks. Tested with ansible-core 2.11.12 and 2.19.2.